### PR TITLE
Added the ability to plug in a log function

### DIFF
--- a/doc/unsplit.md
+++ b/doc/unsplit.md
@@ -8,8 +8,6 @@
 
 Framework for merging mnesia tables after netsplit.
 
-
-
 __Behaviours:__ [`application`](application.md), [`supervisor`](supervisor.md).
 
 __Authors:__ : Ulf Wiger ([`ulf.wiger@erlang-solutions.com`](mailto:ulf.wiger@erlang-solutions.com)).<a name="description"></a>
@@ -25,38 +23,80 @@ __Authors:__ : Ulf Wiger ([`ulf.wiger@erlang-solutions.com`](mailto:ulf.wiger@er
 ##Function Index##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#get_reporter-0">get_reporter/0</a></td><td>Look up the predefined callback module for reporting inconsistencies.</td></tr><tr><td valign="top"><a href="#report_inconsistency-4">report_inconsistency/4</a></td><td>Report an inconcistency to the predefined reporter.</td></tr><tr><td valign="top"><a href="#report_inconsistency-5">report_inconsistency/5</a></td><td>Report an inconsistency to Reporter (an unsplit_reporter behaviour).</td></tr><tr><td valign="top"><a href="#start-2">start/2</a></td><td>Application start callback.</td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td>Application stop callback.</td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#default_log_fun-2">default_log_fun/2</a></td><td>Default implementation of an unsplit log function.</td></tr><tr><td valign="top"><a href="#get_logger-0">get_logger/0</a></td><td>Look up the predefined callback function for logging.</td></tr><tr><td valign="top"><a href="#get_reporter-0">get_reporter/0</a></td><td>Look up the predefined callback module for reporting inconsistencies.</td></tr><tr><td valign="top"><a href="#log_write-2">log_write/2</a></td><td>Writes a log message to the predefined logger.</td></tr><tr><td valign="top"><a href="#log_write-3">log_write/3</a></td><td>Writes a formatted log message to the predefined logger.</td></tr><tr><td valign="top"><a href="#log_write-4">log_write/4</a></td><td>Writes a formatted log message to the predefined logger.</td></tr><tr><td valign="top"><a href="#report_inconsistency-4">report_inconsistency/4</a></td><td>Report an inconcistency to the predefined reporter.</td></tr><tr><td valign="top"><a href="#report_inconsistency-5">report_inconsistency/5</a></td><td>Report an inconsistency to Reporter (an unsplit_reporter behaviour).</td></tr><tr><td valign="top"><a href="#start-2">start/2</a></td><td>Application start callback.</td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td>Application stop callback.</td></tr></table>
 
 
 <a name="functions"></a>
 
 ##Function Details##
 
+<a name="default_log_fun-2"></a>
+
+###default_log_fun/2##
+
+
+<pre>default_log_fun(LogType::<a href="unsplit.md#type-log_type">unsplit:log_type()</a>, Message::string()) -> ok</pre>
+<br></br>
+
+
+Default implementation of an unsplit log function
+<a name="get_logger-0"></a>
+
+###get_logger/0##
+
+
+<pre>get_logger() -> <a href="unsplit.md#type-log_fun">unsplit:log_fun()</a></pre>
+<br></br>
+
+
+Look up the predefined callback function for logging
 <a name="get_reporter-0"></a>
 
 ###get_reporter/0##
-
-
 
 
 <pre>get_reporter() -&gt; module()</pre>
 <br></br>
 
 
-
-
 Look up the predefined callback module for reporting inconsistencies
+<a name="log_write-2"></a>
+
+###log_write/2##
+
+
+<pre>log_write(LogType::<a href="unsplit.md#type-log_type">unsplit:log_type()</a>, Message::string()) -> ok</pre>
+<br></br>
+
+
+Writes a log message to the predefined logger
+<a name="log_write-3"></a>
+
+###log_write/3##
+
+
+<pre>log_write(LogType::<a href="unsplit.md#type-log_type">unsplit:log_type()</a>, Format::string(), Data::[any()]) -> ok</pre>
+<br></br>
+
+
+Writes a formatted log message to the predefined logger
+<a name="log_write-4"></a>
+
+###log_write/4##
+
+
+<pre>log_write(Logger::<a href="unsplit.md#type-log_fun">unsplit:log_fun()</a>, LogType::<a href="unsplit.md#type-log_type">unsplit:log_type()</a>, Format::string(), Data::[any()]) -> ok</pre>
+<br></br>
+
+
+Writes a formatted log message to the predefined logger
 <a name="report_inconsistency-4"></a>
 
 ###report_inconsistency/4##
 
 
-
-
 <pre>report_inconsistency(Tab::Table, Key, ObjA::ObjectA, ObjB::ObjectB) -&gt; ok</pre>
 <br></br>
-
-
 
 
 Report an inconcistency to the predefined reporter
@@ -65,12 +105,8 @@ Report an inconcistency to the predefined reporter
 ###report_inconsistency/5##
 
 
-
-
 <pre>report_inconsistency(Reporter, Tab::Table, Key, ObjA::ObjectA, ObjB::ObjectB) -&gt; ok</pre>
 <br></br>
-
-
 
 
 Report an inconsistency to Reporter (an unsplit_reporter behaviour)
@@ -79,12 +115,8 @@ Report an inconsistency to Reporter (an unsplit_reporter behaviour)
 ###start/2##
 
 
-
-
 <pre>start(X1::Type, X2::Arg) -&gt; {ok, pid()}</pre>
 <br></br>
-
-
 
 
 Application start callback
@@ -93,12 +125,8 @@ Application start callback
 ###stop/1##
 
 
-
-
 <pre>stop(X1::State) -&gt; ok</pre>
 <br></br>
-
-
 
 
 Application stop callback

--- a/include/unsplit.hrl
+++ b/include/unsplit.hrl
@@ -10,3 +10,8 @@
 		    | {ok, any()}
 		    | {ok, merge_actions(), any()}
 		    | {ok, merge_actions(), merge_strategy(), any()}.
+
+-type log_fun() :: fun((LogType :: log_type(), Message :: string()) -> 'ok').
+
+-type log_type() :: 'error' | 'normal'.
+

--- a/src/unsplit.app.src
+++ b/src/unsplit.app.src
@@ -36,6 +36,7 @@
   {registered, []},
   {mod, {unsplit, []}},
   {env, [
-         {reporter, unsplit_reporter}
+         {reporter, unsplit_reporter},
+         {log_fun, {unsplit, default_log_fun}}
         ]}
  ]}.

--- a/src/unsplit_lib.erl
+++ b/src/unsplit_lib.erl
@@ -41,7 +41,7 @@
 %% @end
 %%
 no_action(init, [Tab|_]) ->
-    error_logger:format("Will not merge table ~p~n", [Tab]),
+    unsplit:log_write(error, "Will not merge table ~p~n", [Tab]),
     stop.
 
 %% @spec last_modified(Phase, State) -> merge_ret()
@@ -81,11 +81,11 @@ bag(Objs, S) ->
 last_version(init, [Tab, Attrs, Attr]) ->
     case lists:member(Attr, Attrs) of
         false ->
-            error_logger:format("Cannot merge table ~p."
-                                "Missing ~p attribute~n", [Tab, Attr]),
+            unsplit:log_write(error, "Cannot merge table ~p."
+                                     "Missing ~p attribute~n", [Tab, Attr]),
             stop;
         true ->
-            io:fwrite("Starting merge of ~p (~p)~n", [Tab, Attrs]),
+            unsplit:log_write(normal, "Starting merge of ~p (~p)~n", [Tab, Attrs]),
             {ok, {Tab, pos(Attr, Tab, Attrs)}}
     end;
 last_version(done, _S) ->
@@ -99,11 +99,11 @@ last_version(Objs, {T, P} = S) when is_list(Objs) ->
 vclock(init, [Tab, Attrs, Attr]) ->
     case lists:member(Attr, Attrs) of
         false ->
-            error_logger:format("Cannot merge table ~p."
-                                "Missing ~p attribute~n", [Tab, Attr]),
+            unsplit:log_write(error, "Cannot merge table ~p."
+                                     "Missing ~p attribute~n", [Tab, Attr]),
             stop;
         true ->
-            io:fwrite("Starting merge of ~p (~p)~n", [Tab, Attrs]),
+            unsplit:log_write(normal, "Starting merge of ~p (~p)~n", [Tab, Attrs]),
             {ok, {Tab, pos(Attr, Tab, Attrs)}}
     end;
 vclock(done, _) ->
@@ -127,14 +127,14 @@ vclock(Objs, {T, P} = S) ->
     {ok, Actions, same, S}.
 
 last_version_entry(Obj, T, P) ->
-    io:fwrite("last_version_entry(~p)~n", [Obj]),
+    unsplit:log_write(normal, "last_version_entry(~p)~n", [Obj]),
     compare(Obj, T, P, fun(A, B) when A < B -> left;
 			  (A, B) when A > B -> right;
 			  (_, _) -> neither
 		       end).
 
 compare(Obj, T, P, Comp) ->
-    io:fwrite("compare(~p)~n", [Obj]),
+    unsplit:log_write("compare(~p)~n", [Obj]),
     case Obj of
         {A, []} -> {write, A};
         {[], B} -> {write, B};


### PR DESCRIPTION
Added the ability to plug in a log function in place of the existing
calls to io:fwrite and error_logger:format.  The details are as follows:

(1) Added two new types to unsplit.hrl:

```
* log_type(), which is either the atom 'normal' or the atom 'error'.
  Each log message has one type or the other.
* log_fun(), which is the kind of fun that writes log messages.  It
  takes two arguments: a log_type() and a string().
```

(2) Added a key 'log_fun' to the {unsplit, ...} application environment
    variable in unsplit.app.src.  Its value is a tuple {Module, FunctionName}.

(3) Added a function unsplit:default_log_fun, which is what it sounds like:
    the default log_fun when none is explicitly specified.  It writes normal
    messages using io:fwrite and error messages using error_logger:format,
    mirroring previous functionality.

(4) Added three overloads of a function unsplit:log_write, which writes
    messages (with or without formatting) to whatever log function has
    been configured in the {unsplit, ...} application environment variable.

(5) Added a function unsplit:get_logger, which builds a fun that calls the
    appropriate log_fun.

(6) Replaced all explicit calls to io:fwrite(...) with calls to
    unsplit:log_write(normal, ...) instead.

(7) Replaced all explicit calls to error_logger:format(...) with calls to
    unsplit:log_write(error, ...) instead.

(8) Regenerated unsplit.md documentation file.

When the new 'log_fun' application environment variable has its default
value, unsplit behaves as it did before.  However, logging functionality
can now be plugged in to replace the existing functionality.
